### PR TITLE
device: added camellia to official list

### DIFF
--- a/komodo.devices
+++ b/komodo.devices
@@ -1,4 +1,5 @@
 vayu
+camellia
 olives
 violet
 santoni


### PR DESCRIPTION
Devices called "camellia":
Xiaomi Poco M3 Pro 5G
Xiaomi Redmi Note 10 5G
Xiaomi Redmi Note 10T
Xiaomi Redmi Note 11SE China